### PR TITLE
Import enhancements to use domain/subdomain name instead of ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,41 @@ $ make build
 
 Using the provider
 ----------------------
-## Fill in for each provider
+
+Example DNS records:
+
+```
+resource "cloudflare_record" "cf_record" {
+  domain = "example.com"
+  name   = "subdomain"
+  value  = "otherhost.example.com"
+  type   = "CNAME"
+  ttl    = "3600"
+}
+
+resource "cloudflare_record" "mx_cf_record" {
+  domain = "example.com"
+  name   = "example.com"
+  value  = "mxhost.example.com"
+  priority = "10"
+  type   = "MX"
+  ttl    = "3600"
+}
+
+```
+
+Format for import key: "<domain>/<fqdn>/<record_type>" (ex. "example.com/subdomain.example.com/CNAME")
+
+MX records are handled slightly differently, as they require an additional record index: "<domain>/<fqdn>/MX/<record_index>"
+
+Import command example:
+
+```
+terraform import cloudflare_record.cf_record "example.com/subdomain.example.com/A"
+terraform import cloudflare_record.mx_cf_record[0] "example.com/example.com/MX/0"
+terraform import cloudflare_record.mx_cf_record[1] "example.com/example.com/MX/1"
+```
+
 
 Developing the Provider
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -52,12 +52,11 @@ resource "cloudflare_record" "mx_cf_record" {
   type   = "MX"
   ttl    = "3600"
 }
-
 ```
 
-Format for import key: "<domain>/<fqdn>/<record_type>" (ex. "example.com/subdomain.example.com/CNAME")
+Format for import key: "&lt;domain&gt;/&lt;fqdn&gt;/&lt;record_type&gt;" (ex. "example.com/subdomain.example.com/CNAME")
 
-MX records are handled slightly differently, as they require an additional record index: "<domain>/<fqdn>/MX/<record_index>"
+MX records are handled slightly differently, as they require an additional record index: "&lt;domain&gt;/&lt;fqdn&gt;/MX/&lt;record_index&gt;"
 
 Import command example:
 

--- a/cloudflare/resource_cloudflare_record.go
+++ b/cloudflare/resource_cloudflare_record.go
@@ -223,7 +223,6 @@ func resourceCloudFlareRecordImport(d *schema.ResourceData, meta interface{}) ([
 	re := regexp.MustCompile("^(.*?)/(.*?)/(.*?)(/(.*?))?$")
 	matches := re.FindAllStringSubmatch(id, -1)
 
-	log.Printf("matches: %+v", matches)
 	match_domain := matches[0][1]
 	match_record := matches[0][2]
 	match_type := matches[0][3]
@@ -255,9 +254,7 @@ func resourceCloudFlareRecordImport(d *schema.ResourceData, meta interface{}) ([
 			if err != nil {
 				log.Printf("[ERROR] got error when getting all records: %+v", dnsRecords)
 			}
-			//dnsRecords, _ := client.DNSRecords(zone.ID, cloudflare.DNSRecord{})
 
-			log.Printf("[INFO] Record count: %v", len(dnsRecords))
 			for _, record := range dnsRecords {
 				log.Printf("[INFO] Checking record: %v: %v", record.Name, record.Type)
 				if record.Name == match_record && record.Type == match_type {

--- a/vendor/github.com/cloudflare/cloudflare-go/README.md
+++ b/vendor/github.com/cloudflare/cloudflare-go/README.md
@@ -4,37 +4,45 @@
 [![Build Status](https://img.shields.io/travis/cloudflare/cloudflare-go/master.svg?style=flat-square)](https://travis-ci.org/cloudflare/cloudflare-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cloudflare/cloudflare-go?style=flat-square)](https://goreportcard.com/report/github.com/cloudflare/cloudflare-go)
 
-> **Note**: This library is under active development as we expand it to cover our (expanding!) API.
-Consider the public API of this package a little unstable as we work towards a v1.0.
+> **Note**: This library is under active development as we expand it to cover
+> our (expanding!) API. Consider the public API of this package a little
+> unstable as we work towards a v1.0.
 
-A Go library for interacting with [Cloudflare's API v4](https://api.cloudflare.com/). This library
-allows you to:
+A Go library for interacting with
+[Cloudflare's API v4](https://api.cloudflare.com/). This library allows you to:
 
 * Manage and automate changes to your DNS records within Cloudflare
-* Manage and automate changes to your zones (domains) on Cloudflare, including adding new zones to
-  your account
-* List and modify the status of WAF (Web Application Firewall) rules for your zones
+* Manage and automate changes to your zones (domains) on Cloudflare, including
+  adding new zones to your account
+* List and modify the status of WAF (Web Application Firewall) rules for your
+  zones
 * Fetch Cloudflare's IP ranges for automating your firewall whitelisting
 
-A command-line client, [flarectl](cmd/flarectl), is also available as part of this project.
+A command-line client, [flarectl](cmd/flarectl), is also available as part of
+this project.
 
 ## Features
 
 The current feature list includes:
 
-- [x] DNS Records
-- [x] Zones
-- [x] Web Application Firewall (WAF)
-- [x] Cloudflare IPs
-- [x] User Administration (partial)
-- [x] Virtual DNS Management
-- [ ] Organization Administration
-- [ ] [Railgun](https://www.cloudflare.com/railgun/) administration
-- [ ] [Keyless SSL](https://blog.cloudflare.com/keyless-ssl-the-nitty-gritty-technical-details/)
-- [ ] [Origin CA](https://blog.cloudflare.com/universal-ssl-encryption-all-the-way-to-the-origin-for-free/)
+* [x] DNS Records
+* [x] Zones
+* [x] Web Application Firewall (WAF)
+* [x] Cloudflare IPs
+* [x] User Administration (partial)
+* [x] Virtual DNS Management
+* [x] Custom hostnames
+* [x] Zone Lockdown and User-Agent Block rules
+* [x] Cache purging
+* [ ] Organization Administration
+* [x] [Railgun](https://www.cloudflare.com/railgun/) administration
+* [ ] [Keyless SSL](https://blog.cloudflare.com/keyless-ssl-the-nitty-gritty-technical-details/)
+* [x] [Origin CA](https://blog.cloudflare.com/universal-ssl-encryption-all-the-way-to-the-origin-for-free/)
+* [x] [Load Balancing](https://blog.cloudflare.com/introducing-load-balancing-intelligent-failover-with-cloudflare/)
+* [x] Firewall (partial)
 
-Pull Requests are welcome, but please open an issue (or comment in an existing issue) to discuss any
-non-trivial changes before submitting code.
+Pull Requests are welcome, but please open an issue (or comment in an existing
+issue) to discuss any non-trivial changes before submitting code.
 
 ## Installation
 
@@ -88,8 +96,9 @@ func main() {
 }
 ```
 
-Also refer to the [API documentation](https://godoc.org/github.com/cloudflare/cloudflare-go) for how
-to use this package in-depth.
+Also refer to the
+[API documentation](https://godoc.org/github.com/cloudflare/cloudflare-go) for
+how to use this package in-depth.
 
 # License
 

--- a/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
@@ -12,15 +12,24 @@ import (
 )
 
 const apiURL = "https://api.cloudflare.com/client/v4"
+const (
+	// AuthKeyEmail specifies that we should authenticate with API key and email address
+	AuthKeyEmail = 1 << iota
+	// AuthUserService specifies that we should authenticate with a User-Service key
+	AuthUserService
+)
 
 // API holds the configuration for the current API client. A client should not
 // be modified concurrently.
 type API struct {
-	APIKey     string
-	APIEmail   string
-	BaseURL    string
-	headers    http.Header
-	httpClient *http.Client
+	APIKey            string
+	APIEmail          string
+	APIUserServiceKey string
+	BaseURL           string
+	organizationID    string
+	headers           http.Header
+	httpClient        *http.Client
+	authType          int
 }
 
 // New creates a new Cloudflare v4 API client.
@@ -34,6 +43,7 @@ func New(key, email string, opts ...Option) (*API, error) {
 		APIEmail: email,
 		BaseURL:  apiURL,
 		headers:  make(http.Header),
+		authType: AuthKeyEmail,
 	}
 
 	err := api.parseOptions(opts...)
@@ -48,6 +58,11 @@ func New(key, email string, opts ...Option) (*API, error) {
 	}
 
 	return api, nil
+}
+
+// SetAuthType sets the authentication method (AuthyKeyEmail or AuthUserService).
+func (api *API) SetAuthType(authType int) {
+	api.authType = authType
 }
 
 // ZoneIDByName retrieves a zone's ID from the name.
@@ -67,6 +82,10 @@ func (api *API) ZoneIDByName(zoneName string) (string, error) {
 // makeRequest makes a HTTP request and returns the body as a byte slice,
 // closing it before returnng. params will be serialized to JSON.
 func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, error) {
+	return api.makeRequestWithAuthType(method, uri, params, api.authType)
+}
+
+func (api *API) makeRequestWithAuthType(method, uri string, params interface{}, authType int) ([]byte, error) {
 	// Replace nil with a JSON object if needed
 	var reqBody io.Reader
 	if params != nil {
@@ -79,7 +98,7 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 		reqBody = nil
 	}
 
-	resp, err := api.request(method, uri, reqBody)
+	resp, err := api.request(method, uri, reqBody, authType)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +133,7 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 // request makes a HTTP request to the given API endpoint, returning the raw
 // *http.Response, or an error if one occurred. The caller is responsible for
 // closing the response body.
-func (api *API) request(method, uri string, reqBody io.Reader) (*http.Response, error) {
+func (api *API) request(method, uri string, reqBody io.Reader, authType int) (*http.Response, error) {
 	req, err := http.NewRequest(method, api.BaseURL+uri, reqBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request creation failed")
@@ -122,8 +141,17 @@ func (api *API) request(method, uri string, reqBody io.Reader) (*http.Response, 
 
 	// Apply any user-defined headers first.
 	req.Header = cloneHeader(api.headers)
-	req.Header.Set("X-Auth-Key", api.APIKey)
-	req.Header.Set("X-Auth-Email", api.APIEmail)
+	if authType&AuthKeyEmail != 0 {
+		req.Header.Set("X-Auth-Key", api.APIKey)
+		req.Header.Set("X-Auth-Email", api.APIEmail)
+	}
+	if authType&AuthUserService != 0 {
+		req.Header.Set("X-Auth-User-Service-Key", api.APIUserServiceKey)
+	}
+
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := api.httpClient.Do(req)
 	if err != nil {
@@ -131,6 +159,18 @@ func (api *API) request(method, uri string, reqBody io.Reader) (*http.Response, 
 	}
 
 	return resp, nil
+}
+
+// Returns the base URL to use for API endpoints that exist for both accounts and organizations.
+// If an Organization option was used when creating the API instance, returns the org URL.
+//
+// accountBase is the base URL for endpoints referring to the current user. It exists as a
+// parameter because it is not consistent across APIs.
+func (api *API) userBaseURL(accountBase string) string {
+	if api.organizationID != "" {
+		return "/organizations/" + api.organizationID
+	}
+	return accountBase
 }
 
 // cloneHeader returns a shallow copy of the header.
@@ -160,8 +200,30 @@ type Response struct {
 
 // ResultInfo contains metadata about the Response.
 type ResultInfo struct {
-	Page    int `json:"page"`
-	PerPage int `json:"per_page"`
-	Count   int `json:"count"`
-	Total   int `json:"total_count"`
+	Page       int `json:"page"`
+	PerPage    int `json:"per_page"`
+	TotalPages int `json:"total_pages"`
+	Count      int `json:"count"`
+	Total      int `json:"total_count"`
+}
+
+// RawResponse keeps the result as JSON form
+type RawResponse struct {
+	Response
+	Result json.RawMessage `json:"result"`
+}
+
+// Raw makes a HTTP request with user provided params and returns the
+// result as untouched JSON.
+func (api *API) Raw(method, endpoint string, data interface{}) (json.RawMessage, error) {
+	res, err := api.makeRequest(method, endpoint, data)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r RawResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
 }

--- a/vendor/github.com/cloudflare/cloudflare-go/custom_hostname.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/custom_hostname.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// CustomHostnameSSL represents the SSL section in a given custom hostname.
+type CustomHostnameSSL struct {
+	Status      string `json:"status,omitempty"`
+	Method      string `json:"method,omitempty"`
+	Type        string `json:"type,omitempty"`
+	CnameTarget string `json:"cname_target,omitempty"`
+	CnameName   string `json:"cname_name,omitempty"`
+}
+
+// CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.
+type CustomMetadata map[string]interface{}
+
+// CustomHostname represents a custom hostname in a zone.
+type CustomHostname struct {
+	ID             string            `json:"id,omitempty"`
+	Hostname       string            `json:"hostname,omitempty"`
+	SSL            CustomHostnameSSL `json:"ssl,omitempty"`
+	CustomMetadata CustomMetadata    `json:"custom_metadata,omitempty"`
+}
+
+// CustomHostNameResponse represents a response from the Custom Hostnames endpoints.
+type CustomHostnameResponse struct {
+	Result CustomHostname `json:"result"`
+	Response
+}
+
+// CustomHostnameListResponse represents a response from the Custom Hostnames endpoints.
+type CustomHostnameListResponse struct {
+	Result []CustomHostname `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// Modify SSL configuration for the given custom hostname in the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-update-custom-hostname-configuration
+func (api *API) UpdateCustomHostnameSSL(zoneID string, customHostnameID string, ssl CustomHostnameSSL) (CustomHostname, error) {
+	return CustomHostname{}, errors.New("Not implemented")
+}
+
+// Delete a custom hostname (and any issued SSL certificates)
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-delete-a-custom-hostname-and-any-issued-ssl-certificates-
+func (api *API) DeleteCustomHostname(zoneID string, customHostnameID string) error {
+	uri := "/zones/" + zoneID + "/custom_hostnames/" + customHostnameID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response *CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}
+
+// CreateCustomHostname creates a new custom hostname and requests that an SSL certificate be issued for it.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname
+func (api *API) CreateCustomHostname(zoneID string, ch CustomHostname) (*CustomHostnameResponse, error) {
+	uri := "/zones/" + zoneID + "/custom_hostnames"
+	res, err := api.makeRequest("POST", uri, ch)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response *CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// CustomHostnames fetches custom hostnames for the given zone,
+// by applying filter.Hostname if not empty and scoping the result to page'th 50 items.
+//
+// The returned ResultInfo can be used to implement pagination.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames
+func (api *API) CustomHostnames(zoneID string, page int, filter CustomHostname) ([]CustomHostname, ResultInfo, error) {
+	v := url.Values{}
+	v.Set("per_page", "50")
+	v.Set("page", strconv.Itoa(page))
+	if filter.Hostname != "" {
+		v.Set("hostname", filter.Hostname)
+	}
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/custom_hostnames" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []CustomHostname{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var customHostnameListResponse CustomHostnameListResponse
+	err = json.Unmarshal(res, &customHostnameListResponse)
+	if err != nil {
+		return []CustomHostname{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	return customHostnameListResponse.Result, customHostnameListResponse.ResultInfo, nil
+}
+
+// CustomHostname inspects the given custom hostname in the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-custom-hostname-configuration-details
+func (api *API) CustomHostname(zoneID string, customHostnameID string) (CustomHostname, error) {
+	uri := "/zones/" + zoneID + "/custom_hostnames/" + customHostnameID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return CustomHostname{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return CustomHostname{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// CustomHostnameIDByName retrieves the ID for the given hostname in the given zone.
+func (api *API) CustomHostnameIDByName(zoneID string, hostname string) (string, error) {
+	customHostnames, _, err := api.CustomHostnames(zoneID, 1, CustomHostname{Hostname: hostname})
+	if err != nil {
+		return "", errors.Wrap(err, "CustomHostnames command failed")
+	}
+	for _, ch := range customHostnames {
+		if ch.Hostname == hostname {
+			return ch.ID, nil
+		}
+	}
+	return "", errors.New("CustomHostname could not be found")
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/dns.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/dns.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"encoding/json"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -29,20 +30,21 @@ type DNSRecord struct {
 
 // DNSRecordResponse represents the response from the DNS endpoint.
 type DNSRecordResponse struct {
-	Response
 	Result DNSRecord `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
 }
 
 // DNSListResponse represents the response from the list DNS records endpoint.
 type DNSListResponse struct {
-	Response
 	Result []DNSRecord `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
 }
 
 // CreateDNSRecord creates a DNS record for the zone identifier.
-// API reference:
-//   https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
-//   POST /zones/:zone_identifier/dns_records
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
 func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) (*DNSRecordResponse, error) {
 	uri := "/zones/" + zoneID + "/dns_records"
 	res, err := api.makeRequest("POST", uri, rr)
@@ -60,12 +62,15 @@ func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) (*DNSRecordResponse
 }
 
 // DNSRecords returns a slice of DNS records for the given zone identifier.
-// API reference:
-//   https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
-//   GET /zones/:zone_identifier/dns_records
+//
+// This takes a DNSRecord to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
 func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	// Construct a query string
 	v := url.Values{}
+	// Request as many records as possible per page - API max is 50
+	v.Set("per_page", "50")
 	if rr.Name != "" {
 		v.Set("name", rr.Name)
 	}
@@ -75,28 +80,39 @@ func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	if rr.Content != "" {
 		v.Set("content", rr.Content)
 	}
+
 	var query string
-	if len(v) > 0 {
+	var records []DNSRecord
+	page := 1
+
+	// Loop over makeRequest until what we've fetched all records
+	for {
+		v.Set("page", strconv.Itoa(page))
 		query = "?" + v.Encode()
+		uri := "/zones/" + zoneID + "/dns_records" + query
+		res, err := api.makeRequest("GET", uri, nil)
+		if err != nil {
+			return []DNSRecord{}, errors.Wrap(err, errMakeRequestError)
+		}
+		var r DNSListResponse
+		err = json.Unmarshal(res, &r)
+		if err != nil {
+			return []DNSRecord{}, errors.Wrap(err, errUnmarshalError)
+		}
+		records = append(records, r.Result...)
+		if r.ResultInfo.Page >= r.ResultInfo.TotalPages {
+			break
+		}
+		// Loop around and fetch the next page
+		page++
 	}
-	uri := "/zones/" + zoneID + "/dns_records" + query
-	res, err := api.makeRequest("GET", uri, nil)
-	if err != nil {
-		return []DNSRecord{}, errors.Wrap(err, errMakeRequestError)
-	}
-	var r DNSListResponse
-	err = json.Unmarshal(res, &r)
-	if err != nil {
-		return []DNSRecord{}, errors.Wrap(err, errUnmarshalError)
-	}
-	return r.Result, nil
+	return records, nil
 }
 
 // DNSRecord returns a single DNS record for the given zone & record
 // identifiers.
-// API reference:
-//   https://api.cloudflare.com/#dns-records-for-a-zone-dns-record-details
-//   GET /zones/:zone_identifier/dns_records/:identifier
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-dns-record-details
 func (api *API) DNSRecord(zoneID, recordID string) (DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("GET", uri, nil)
@@ -113,9 +129,8 @@ func (api *API) DNSRecord(zoneID, recordID string) (DNSRecord, error) {
 
 // UpdateDNSRecord updates a single DNS record for the given zone & record
 // identifiers.
-// API reference:
-//   https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
-//   PUT /zones/:zone_identifier/dns_records/:identifier
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
 func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
 	rec, err := api.DNSRecord(zoneID, recordID)
 	if err != nil {
@@ -142,9 +157,8 @@ func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
 
 // DeleteDNSRecord deletes a single DNS record for the given zone & record
 // identifiers.
-// API reference:
-//   https://api.cloudflare.com/#dns-records-for-a-zone-delete-dns-record
-//   DELETE /zones/:zone_identifier/dns_records/:identifier
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-delete-dns-record
 func (api *API) DeleteDNSRecord(zoneID, recordID string) error {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("DELETE", uri, nil)

--- a/vendor/github.com/cloudflare/cloudflare-go/errors.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/errors.go
@@ -2,9 +2,10 @@ package cloudflare
 
 // Error messages
 const (
-	errEmptyCredentials = "invalid credentials: key & email must not be empty"
-	errMakeRequestError = "error from makeRequest"
-	errUnmarshalError   = "error unmarshalling the JSON response"
+	errEmptyCredentials     = "invalid credentials: key & email must not be empty"
+	errMakeRequestError     = "error from makeRequest"
+	errUnmarshalError       = "error unmarshalling the JSON response"
+	errRequestNotSuccessful = "error reported by API"
 )
 
 var _ Error = &UserError{}

--- a/vendor/github.com/cloudflare/cloudflare-go/firewall.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/firewall.go
@@ -1,0 +1,241 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// AccessRule represents a firewall access rule.
+type AccessRule struct {
+	ID            string                  `json:"id,omitempty"`
+	Notes         string                  `json:"notes,omitempty"`
+	AllowedModes  []string                `json:"allowed_modes,omitempty"`
+	Mode          string                  `json:"mode,omitempty"`
+	Configuration AccessRuleConfiguration `json:"configuration,omitempty"`
+	Scope         AccessRuleScope         `json:"scope,omitempty"`
+	CreatedOn     time.Time               `json:"created_on,omitempty"`
+	ModifiedOn    time.Time               `json:"modified_on,omitempty"`
+}
+
+// AccessRuleConfiguration represents the configuration of a firewall
+// access rule.
+type AccessRuleConfiguration struct {
+	Target string `json:"target,omitempty"`
+	Value  string `json:"value,omitempty"`
+}
+
+// AccessRuleScope represents the scope of a firewall access rule.
+type AccessRuleScope struct {
+	ID    string `json:"id,omitempty"`
+	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+// AccessRuleResponse represents the response from the firewall access
+// rule endpoint.
+type AccessRuleResponse struct {
+	Result AccessRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// AccessRuleListResponse represents the response from the list access rules
+// endpoint.
+type AccessRuleListResponse struct {
+	Result []AccessRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// ListUserAccessRules returns a slice of access rules for the logged-in user.
+//
+// This takes an AccessRule to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-list-access-rules
+func (api *API) ListUserAccessRules(accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	return api.listAccessRules("/user", accessRule, page)
+}
+
+// CreateUserAccessRule creates a firewall access rule for the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-create-access-rule
+func (api *API) CreateUserAccessRule(accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.createAccessRule("/user", accessRule)
+}
+
+// UpdateUserAccessRule updates a single access rule for the logged-in user &
+// given access rule identifier.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-update-access-rule
+func (api *API) UpdateUserAccessRule(accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.updateAccessRule("/user", accessRuleID, accessRule)
+}
+
+// DeleteUserAccessRule deletes a single access rule for the logged-in user and
+// access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-update-access-rule
+func (api *API) DeleteUserAccessRule(accessRuleID string) (*AccessRuleResponse, error) {
+	return api.deleteAccessRule("/user", accessRuleID)
+}
+
+// ListZoneAccessRules returns a slice of access rules for the given zone
+// identifier.
+//
+// This takes an AccessRule to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-list-access-rules
+func (api *API) ListZoneAccessRules(zoneID string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	return api.listAccessRules("/zones/"+zoneID, accessRule, page)
+}
+
+// CreateZoneAccessRule creates a firewall access rule for the given zone
+// identifier.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-create-access-rule
+func (api *API) CreateZoneAccessRule(zoneID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.createAccessRule("/zones/"+zoneID, accessRule)
+}
+
+// UpdateZoneAccessRule updates a single access rule for the given zone &
+// access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-update-access-rule
+func (api *API) UpdateZoneAccessRule(zoneID, accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.updateAccessRule("/zones/"+zoneID, accessRuleID, accessRule)
+}
+
+// DeleteZoneAccessRule deletes a single access rule for the given zone and
+// access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-delete-access-rule
+func (api *API) DeleteZoneAccessRule(zoneID, accessRuleID string) (*AccessRuleResponse, error) {
+	return api.deleteAccessRule("/zones/"+zoneID, accessRuleID)
+}
+
+// ListOrganizationAccessRules returns a slice of access rules for the given
+// organization identifier.
+//
+// This takes an AccessRule to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-list-access-rules
+func (api *API) ListOrganizationAccessRules(organizationID string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	return api.listAccessRules("/organizations/"+organizationID, accessRule, page)
+}
+
+// CreateOrganizationAccessRule creates a firewall access rule for the given
+// organization identifier.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-create-access-rule
+func (api *API) CreateOrganizationAccessRule(organizationID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.createAccessRule("/organizations/"+organizationID, accessRule)
+}
+
+// UpdateOrganizationAccessRule updates a single access rule for the given
+// organization & access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-update-access-rule
+func (api *API) UpdateOrganizationAccessRule(organizationID, accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.updateAccessRule("/organizations/"+organizationID, accessRuleID, accessRule)
+}
+
+// DeleteOrganizationAccessRule deletes a single access rule for the given
+// organization and access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-delete-access-rule
+func (api *API) DeleteOrganizationAccessRule(organizationID, accessRuleID string) (*AccessRuleResponse, error) {
+	return api.deleteAccessRule("/organizations/"+organizationID, accessRuleID)
+}
+
+func (api *API) listAccessRules(prefix string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	// Construct a query string
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+	v.Set("page", strconv.Itoa(page))
+	// Request as many rules as possible per page - API max is 100
+	v.Set("per_page", "100")
+	if accessRule.Notes != "" {
+		v.Set("notes", accessRule.Notes)
+	}
+	if accessRule.Mode != "" {
+		v.Set("mode", accessRule.Mode)
+	}
+	if accessRule.Scope.Type != "" {
+		v.Set("scope_type", accessRule.Scope.Type)
+	}
+	if accessRule.Configuration.Value != "" {
+		v.Set("configuration_value", accessRule.Configuration.Value)
+	}
+	if accessRule.Configuration.Target != "" {
+		v.Set("configuration_target", accessRule.Configuration.Target)
+	}
+	v.Set("page", strconv.Itoa(page))
+	query := "?" + v.Encode()
+
+	uri := prefix + "/firewall/access_rules/rules" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return response, nil
+}
+
+func (api *API) createAccessRule(prefix string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	uri := prefix + "/firewall/access_rules/rules"
+	res, err := api.makeRequest("POST", uri, accessRule)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+func (api *API) updateAccessRule(prefix, accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	uri := prefix + "/firewall/access_rules/rules/" + accessRuleID
+	res, err := api.makeRequest("PATCH", uri, accessRule)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return response, nil
+}
+
+func (api *API) deleteAccessRule(prefix, accessRuleID string) (*AccessRuleResponse, error) {
+	uri := prefix + "/firewall/access_rules/rules/" + accessRuleID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/ips.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/ips.go
@@ -8,27 +8,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-// IPRanges contains lists of IPv4 and IPv6 CIDRs
+// IPRanges contains lists of IPv4 and IPv6 CIDRs.
 type IPRanges struct {
 	IPv4CIDRs []string `json:"ipv4_cidrs"`
 	IPv6CIDRs []string `json:"ipv6_cidrs"`
 }
 
-// IPsResponse is the API response containing a list of IPs
+// IPsResponse is the API response containing a list of IPs.
 type IPsResponse struct {
 	Response
 	Result IPRanges `json:"result"`
 }
 
-/*
-IPs gets a list of Cloudflare's IP ranges
-
-This does not require logging in to the API.
-
-API reference:
-  https://api.cloudflare.com/#cloudflare-ips
-  GET /client/v4/ips
-*/
+// IPs gets a list of Cloudflare's IP ranges.
+//
+// This does not require logging in to the API.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ips
 func IPs() (IPRanges, error) {
 	resp, err := http.Get(apiURL + "/ips")
 	if err != nil {

--- a/vendor/github.com/cloudflare/cloudflare-go/keyless.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/keyless.go
@@ -22,36 +22,31 @@ type KeylessSSLResponse struct {
 }
 
 // CreateKeyless creates a new Keyless SSL configuration for the zone.
-// API reference:
-// 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-create-a-keyless-ssl-configuration
-// 	POST /zones/:zone_identifier/keyless_certificates
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-create-a-keyless-ssl-configuration
 func (api *API) CreateKeyless() {
 }
 
 // ListKeyless lists Keyless SSL configurations for a zone.
-// API reference:
-// 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-list-keyless-ssls
-// 	GET /zones/:zone_identifier/keyless_certificates
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-list-keyless-ssls
 func (api *API) ListKeyless() {
 }
 
 // Keyless provides the configuration for a given Keyless SSL identifier.
-// API reference:
-// 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-keyless-ssl-details
-// 	GET /zones/:zone_identifier/keyless_certificates/:identifier
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-keyless-ssl-details
 func (api *API) Keyless() {
 }
 
 // UpdateKeyless updates an existing Keyless SSL configuration.
-// API reference:
-// 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-update-keyless-configuration
-// 	PATCH /zones/:zone_identifier/keyless_certificates/:identifier
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-update-keyless-configuration
 func (api *API) UpdateKeyless() {
 }
 
 // DeleteKeyless deletes an existing Keyless SSL configuration.
-// API reference:
-// 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-delete-keyless-configuration
-// 	DELETE /zones/:zone_identifier/keyless_certificates/:identifier
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-delete-keyless-configuration
 func (api *API) DeleteKeyless() {
 }

--- a/vendor/github.com/cloudflare/cloudflare-go/load_balancing.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/load_balancing.go
@@ -1,0 +1,323 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// LoadBalancerPool represents a load balancer pool's properties.
+type LoadBalancerPool struct {
+	ID                string               `json:"id,omitempty"`
+	CreatedOn         *time.Time           `json:"created_on,omitempty"`
+	ModifiedOn        *time.Time           `json:"modified_on,omitempty"`
+	Description       string               `json:"description"`
+	Name              string               `json:"name"`
+	Enabled           bool                 `json:"enabled"`
+	Monitor           string               `json:"monitor,omitempty"`
+	Origins           []LoadBalancerOrigin `json:"origins"`
+	NotificationEmail string               `json:"notification_email,omitempty"`
+}
+
+type LoadBalancerOrigin struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	Enabled bool   `json:"enabled"`
+}
+
+// LoadBalancerMonitor represents a load balancer monitor's properties.
+type LoadBalancerMonitor struct {
+	ID            string              `json:"id,omitempty"`
+	CreatedOn     *time.Time          `json:"created_on,omitempty"`
+	ModifiedOn    *time.Time          `json:"modified_on,omitempty"`
+	Type          string              `json:"type"`
+	Description   string              `json:"description"`
+	Method        string              `json:"method"`
+	Path          string              `json:"path"`
+	Header        map[string][]string `json:"header"`
+	Timeout       int                 `json:"timeout"`
+	Retries       int                 `json:"retries"`
+	Interval      int                 `json:"interval"`
+	ExpectedBody  string              `json:"expected_body"`
+	ExpectedCodes string              `json:"expected_codes"`
+}
+
+// LoadBalancer represents a load balancer's properties.
+type LoadBalancer struct {
+	ID           string              `json:"id,omitempty"`
+	CreatedOn    *time.Time          `json:"created_on,omitempty"`
+	ModifiedOn   *time.Time          `json:"modified_on,omitempty"`
+	Description  string              `json:"description"`
+	Name         string              `json:"name"`
+	TTL          int                 `json:"ttl,omitempty"`
+	FallbackPool string              `json:"fallback_pool"`
+	DefaultPools []string            `json:"default_pools"`
+	RegionPools  map[string][]string `json:"region_pools"`
+	PopPools     map[string][]string `json:"pop_pools"`
+	Proxied      bool                `json:"proxied"`
+}
+
+// loadBalancerPoolResponse represents the response from the load balancer pool endpoints.
+type loadBalancerPoolResponse struct {
+	Response
+	Result LoadBalancerPool `json:"result"`
+}
+
+// loadBalancerPoolListResponse represents the response from the List Pools endpoint.
+type loadBalancerPoolListResponse struct {
+	Response
+	Result     []LoadBalancerPool `json:"result"`
+	ResultInfo ResultInfo         `json:"result_info"`
+}
+
+// loadBalancerMonitorResponse represents the response from the load balancer monitor endpoints.
+type loadBalancerMonitorResponse struct {
+	Response
+	Result LoadBalancerMonitor `json:"result"`
+}
+
+// loadBalancerMonitorListResponse represents the response from the List Monitors endpoint.
+type loadBalancerMonitorListResponse struct {
+	Response
+	Result     []LoadBalancerMonitor `json:"result"`
+	ResultInfo ResultInfo            `json:"result_info"`
+}
+
+// loadBalancerResponse represents the response from the load balancer endpoints.
+type loadBalancerResponse struct {
+	Response
+	Result LoadBalancer `json:"result"`
+}
+
+// loadBalancerListResponse represents the response from the List Load Balancers endpoint.
+type loadBalancerListResponse struct {
+	Response
+	Result     []LoadBalancer `json:"result"`
+	ResultInfo ResultInfo     `json:"result_info"`
+}
+
+// CreateLoadBalancerPool creates a new load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-create-a-pool
+func (api *API) CreateLoadBalancerPool(pool LoadBalancerPool) (LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools"
+	res, err := api.makeRequest("POST", uri, pool)
+	if err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListLoadBalancerPools lists load balancer pools connected to an account.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-list-pools
+func (api *API) ListLoadBalancerPools() ([]LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolListResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LoadBalancerPoolDetails returns the details for a load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-pool-details
+func (api *API) LoadBalancerPoolDetails(poolID string) (LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools/" + poolID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteLoadBalancerPool disables and deletes a load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-delete-a-pool
+func (api *API) DeleteLoadBalancerPool(poolID string) error {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools/" + poolID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}
+
+// ModifyLoadBalancerPool modifies a configured load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-modify-a-pool
+func (api *API) ModifyLoadBalancerPool(pool LoadBalancerPool) (LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools/" + pool.ID
+	res, err := api.makeRequest("PUT", uri, pool)
+	if err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// CreateLoadBalancerMonitor creates a new load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-create-a-monitor
+func (api *API) CreateLoadBalancerMonitor(monitor LoadBalancerMonitor) (LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors"
+	res, err := api.makeRequest("POST", uri, monitor)
+	if err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListLoadBalancerMonitors lists load balancer monitors connected to an account.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-list-monitors
+func (api *API) ListLoadBalancerMonitors() ([]LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorListResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LoadBalancerMonitorDetails returns the details for a load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-monitor-details
+func (api *API) LoadBalancerMonitorDetails(monitorID string) (LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors/" + monitorID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteLoadBalancerMonitor disables and deletes a load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-delete-a-monitor
+func (api *API) DeleteLoadBalancerMonitor(monitorID string) error {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors/" + monitorID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}
+
+// ModifyLoadBalancerMonitor modifies a configured load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-modify-a-monitor
+func (api *API) ModifyLoadBalancerMonitor(monitor LoadBalancerMonitor) (LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors/" + monitor.ID
+	res, err := api.makeRequest("PUT", uri, monitor)
+	if err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// CreateLoadBalancer creates a new load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-create-a-load-balancer
+func (api *API) CreateLoadBalancer(zoneID string, lb LoadBalancer) (LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers"
+	res, err := api.makeRequest("POST", uri, lb)
+	if err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListLoadBalancers lists load balancers configured on a zone.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-list-load-balancers
+func (api *API) ListLoadBalancers(zoneID string) ([]LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerListResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LoadBalancerDetails returns the details for a load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-load-balancer-details
+func (api *API) LoadBalancerDetails(zoneID, lbID string) (LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers/" + lbID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteLoadBalancer disables and deletes a load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-delete-a-load-balancer
+func (api *API) DeleteLoadBalancer(zoneID, lbID string) error {
+	uri := "/zones/" + zoneID + "/load_balancers/" + lbID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}
+
+// ModifyLoadBalancer modifies a configured load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-modify-a-load-balancer
+func (api *API) ModifyLoadBalancer(zoneID string, lb LoadBalancer) (LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers/" + lb.ID
+	res, err := api.makeRequest("PUT", uri, lb)
+	if err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/lockdown.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/lockdown.go
@@ -1,0 +1,150 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// ZoneLockdown represents a Zone Lockdown rule. A rule only permits access to
+// the provided URL pattern(s) from the given IP address(es) or subnet(s).
+type ZoneLockdown struct {
+	ID             string               `json:"id"`
+	Description    string               `json:"description"`
+	URLs           []string             `json:"urls"`
+	Configurations []ZoneLockdownConfig `json:"configurations"`
+	Paused         bool                 `json:"paused"`
+}
+
+// ZoneLockdownConfig represents a Zone Lockdown config, which comprises
+// a Target ("ip" or "ip_range") and a Value (an IP address or IP+mask,
+// respectively.)
+type ZoneLockdownConfig struct {
+	Target string `json:"target"`
+	Value  string `json:"value"`
+}
+
+// ZoneLockdownResponse represents a response from the Zone Lockdown endpoint.
+type ZoneLockdownResponse struct {
+	Result ZoneLockdown `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// ZoneLockdownListResponse represents a response from the List Zone Lockdown
+// endpoint.
+type ZoneLockdownListResponse struct {
+	Result []ZoneLockdown `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// CreateZoneLockdown creates a Zone ZoneLockdown rule for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-create-a-ZoneLockdown-rule
+func (api *API) CreateZoneLockdown(zoneID string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns"
+	res, err := api.makeRequest("POST", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateZoneLockdown updates a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-update-ZoneLockdown-rule
+func (api *API) UpdateZoneLockdown(zoneID string, id string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns"
+	res, err := api.makeRequest("PUT", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// DeleteZoneLockdown deletes a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-delete-ZoneLockdown-rule
+func (api *API) DeleteZoneLockdown(zoneID string, id string) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns/" + id
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ZoneLockdown retrieves a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-ZoneLockdown-rule-details
+func (api *API) ZoneLockdown(zoneID string, id string) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns/" + id
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ListZoneLockdowns retrieves a list of Zone ZoneLockdown rules for a given
+// zone ID by page number.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-list-ZoneLockdown-rules
+func (api *API) ListZoneLockdowns(zoneID string, page int) (*ZoneLockdownListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/firewall/lockdowns" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/options.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/options.go
@@ -22,6 +22,15 @@ func Headers(headers http.Header) Option {
 	}
 }
 
+// Organization allows you to apply account-level changes (Load Balancing, Railguns)
+// to an organization instead.
+func UsingOrganization(orgID string) Option {
+	return func(api *API) error {
+		api.organizationID = orgID
+		return nil
+	}
+}
+
 // parseOptions parses the supplied options functions and returns a configured
 // *API instance.
 func (api *API) parseOptions(opts ...Option) error {

--- a/vendor/github.com/cloudflare/cloudflare-go/organizations.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/organizations.go
@@ -1,5 +1,12 @@
 package cloudflare
 
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
 // Organization represents a multi-user organization.
 type Organization struct {
 	ID          string   `json:"id,omitempty"`
@@ -9,9 +16,170 @@ type Organization struct {
 	Roles       []string `json:"roles,omitempty"`
 }
 
-// OrganizationResponse represents the response from the Organization endpoint.
-type OrganizationResponse struct {
+// organizationResponse represents the response from the Organization endpoint.
+type organizationResponse struct {
 	Response
 	Result     []Organization `json:"result"`
-	ResultInfo ResultInfo     `json:"result_info"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationMember has details on a member.
+type OrganizationMember struct {
+	ID     string             `json:"id,omitempty"`
+	Name   string             `json:"name,omitempty"`
+	Email  string             `json:"email,omitempty"`
+	Status string             `json:"status,omitempty"`
+	Roles  []OrganizationRole `json:"roles,omitempty"`
+}
+
+// OrganizationInvite has details on an invite.
+type OrganizationInvite struct {
+	ID                 string             `json:"id,omitempty"`
+	InvitedMemberID    string             `json:"invited_member_id,omitempty"`
+	InvitedMemberEmail string             `json:"invited_member_email,omitempty"`
+	OrganizationID     string             `json:"organization_id,omitempty"`
+	OrganizationName   string             `json:"organization_name,omitempty"`
+	Roles              []OrganizationRole `json:"roles,omitempty"`
+	InvitedBy          string             `json:"invited_by,omitempty"`
+	InvitedOn          *time.Time         `json:"invited_on,omitempty"`
+	ExpiresOn          *time.Time         `json:"expires_on,omitempty"`
+	Status             string             `json:"status,omitempty"`
+}
+
+// OrganizationRole has details on a role.
+type OrganizationRole struct {
+	ID          string   `json:"id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+// OrganizationDetails represents details of an organization.
+type OrganizationDetails struct {
+	ID      string               `json:"id,omitempty"`
+	Name    string               `json:"name,omitempty"`
+	Members []OrganizationMember `json:"members"`
+	Invites []OrganizationInvite `json:"invites"`
+	Roles   []OrganizationRole   `json:"roles,omitempty"`
+}
+
+// organizationDetailsResponse represents the response from the OrganizationDetails endpoint.
+type organizationDetailsResponse struct {
+	Response
+	Result OrganizationDetails `json:"result"`
+}
+
+// ListOrganizations lists organizations of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#user-s-organizations-list-organizations
+func (api *API) ListOrganizations() ([]Organization, ResultInfo, error) {
+	var r organizationResponse
+	res, err := api.makeRequest("GET", "/user/organizations", nil)
+	if err != nil {
+		return []Organization{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []Organization{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}
+
+// OrganizationDetails returns details for the specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organizations-organization-details
+func (api *API) OrganizationDetails(organizationID string) (OrganizationDetails, error) {
+	var r organizationDetailsResponse
+	uri := "/organizations/" + organizationID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return OrganizationDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return OrganizationDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}
+
+// organizationMembersResponse represents the response from the Organization members endpoint.
+type organizationMembersResponse struct {
+	Response
+	Result     []OrganizationMember `json:"result"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationMembers returns list of members for specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organization-members-list-members
+func (api *API) OrganizationMembers(organizationID string) ([]OrganizationMember, ResultInfo, error) {
+	var r organizationMembersResponse
+	uri := "/organizations/" + organizationID + "/members"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []OrganizationMember{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []OrganizationMember{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}
+
+// organizationInvitesResponse represents the response from the Organization invites endpoint.
+type organizationInvitesResponse struct {
+	Response
+	Result     []OrganizationInvite `json:"result"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationMembers returns list of invites for specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organization-invites
+func (api *API) OrganizationInvites(organizationID string) ([]OrganizationInvite, ResultInfo, error) {
+	var r organizationInvitesResponse
+	uri := "/organizations/" + organizationID + "/invites"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []OrganizationInvite{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []OrganizationInvite{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}
+
+// organizationRolesResponse represents the response from the Organization roles endpoint.
+type organizationRolesResponse struct {
+	Response
+	Result     []OrganizationRole `json:"result"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationRoles returns list of roles for specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organization-roles-list-roles
+func (api *API) OrganizationRoles(organizationID string) ([]OrganizationRole, ResultInfo, error) {
+	var r organizationRolesResponse
+	uri := "/organizations/" + organizationID + "/roles"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []OrganizationRole{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []OrganizationRole{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
 }

--- a/vendor/github.com/cloudflare/cloudflare-go/origin_ca.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/origin_ca.go
@@ -1,0 +1,168 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// OriginCACertificate represents a Cloudflare-issued certificate.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca
+type OriginCACertificate struct {
+	ID              string    `json:"id"`
+	Certificate     string    `json:"certificate"`
+	Hostnames       []string  `json:"hostnames"`
+	ExpiresOn       time.Time `json:"expires_on"`
+	RequestType     string    `json:"request_type"`
+	RequestValidity int       `json:"requested_validity"`
+	CSR             string    `json:"csr"`
+}
+
+// OriginCACertificateListOptions represents the parameters used to list Cloudflare-issued certificates.
+type OriginCACertificateListOptions struct {
+	ZoneID string
+}
+
+// OriginCACertificateID represents the ID of the revoked certificate from the Revoke Certificate endpoint.
+type OriginCACertificateID struct {
+	ID string `json:"id"`
+}
+
+// originCACertificateResponse represents the response from the Create Certificate and the Certificate Details endpoints.
+type originCACertificateResponse struct {
+	Response
+	Result OriginCACertificate `json:"result"`
+}
+
+// originCACertificateResponseList represents the response from the List Certificates endpoint.
+type originCACertificateResponseList struct {
+	Response
+	Result     []OriginCACertificate `json:"result"`
+	ResultInfo ResultInfo            `json:"result_info"`
+}
+
+// originCACertificateResponseRevoke represents the response from the Revoke Certificate endpoint.
+type originCACertificateResponseRevoke struct {
+	Response
+	Result OriginCACertificateID `json:"result"`
+}
+
+// CreateOriginCertificate creates a Cloudflare-signed certificate.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-create-certificate
+func (api *API) CreateOriginCertificate(certificate OriginCACertificate) (*OriginCACertificate, error) {
+	uri := "/certificates"
+	res, err := api.makeRequestWithAuthType("POST", uri, certificate, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponse
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return &originResponse.Result, nil
+}
+
+// OriginCertificates lists all Cloudflare-issued certificates.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-list-certificates
+func (api *API) OriginCertificates(options OriginCACertificateListOptions) ([]OriginCACertificate, error) {
+	v := url.Values{}
+	if options.ZoneID != "" {
+		v.Set("zone_id", options.ZoneID)
+	}
+	uri := "/certificates" + "?" + v.Encode()
+	res, err := api.makeRequestWithAuthType("GET", uri, nil, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponseList
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return originResponse.Result, nil
+}
+
+// OriginCertificate returns the details for a Cloudflare-issued certificate.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-certificate-details
+func (api *API) OriginCertificate(certificateID string) (*OriginCACertificate, error) {
+	uri := "/certificates/" + certificateID
+	res, err := api.makeRequestWithAuthType("GET", uri, nil, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponse
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return &originResponse.Result, nil
+}
+
+// RevokeOriginCertificate revokes a created certificate for a zone.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-revoke-certificate
+func (api *API) RevokeOriginCertificate(certificateID string) (*OriginCACertificateID, error) {
+	uri := "/certificates/" + certificateID
+	res, err := api.makeRequestWithAuthType("DELETE", uri, nil, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponseRevoke
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return &originResponse.Result, nil
+
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/pagerules.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/pagerules.go
@@ -7,12 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-/*
-PageRuleTarget is the target to evaluate on a request.
-
-Currently Target must always be "url" and Operator must be "matches". Value
-is the URL pattern to match against.
-*/
+// PageRuleTarget is the target to evaluate on a request.
+//
+// Currently Target must always be "url" and Operator must be "matches". Value
+// is the URL pattern to match against.
 type PageRuleTarget struct {
 	Target     string `json:"target"`
 	Constraint struct {
@@ -52,7 +50,7 @@ type PageRuleAction struct {
 	Value interface{} `json:"value"`
 }
 
-// PageRuleActions maps API action IDs to human-readable strings
+// PageRuleActions maps API action IDs to human-readable strings.
 var PageRuleActions = map[string]string{
 	"always_online":       "Always Online",            // Value of type string
 	"always_use_https":    "Always Use HTTPS",         // Value of type interface{}
@@ -103,13 +101,9 @@ type PageRulesResponse struct {
 	Result   []PageRule `json:"result"`
 }
 
-/*
-CreatePageRule creates a new Page Rule for a zone.
-
-API reference:
-  https://api.cloudflare.com/#page-rules-for-a-zone-create-a-page-rule
-  POST /zones/:zone_identifier/pagerules
-*/
+// CreatePageRule creates a new Page Rule for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-create-a-page-rule
 func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("POST", uri, rule)
@@ -124,13 +118,9 @@ func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
 	return nil
 }
 
-/*
-ListPageRules returns all Page Rules for a zone.
-
-API reference:
-  https://api.cloudflare.com/#page-rules-for-a-zone-list-page-rules
-  GET /zones/:zone_identifier/pagerules
-*/
+// ListPageRules returns all Page Rules for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-list-page-rules
 func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("GET", uri, nil)
@@ -145,13 +135,9 @@ func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
 	return r.Result, nil
 }
 
-/*
-PageRule fetches detail about one Page Rule for a zone.
-
-API reference:
-  https://api.cloudflare.com/#page-rules-for-a-zone-page-rule-details
-  GET /zones/:zone_identifier/pagerules/:identifier
-*/
+// PageRule fetches detail about one Page Rule for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-page-rule-details
 func (api *API) PageRule(zoneID, ruleID string) (PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("GET", uri, nil)
@@ -166,14 +152,10 @@ func (api *API) PageRule(zoneID, ruleID string) (PageRule, error) {
 	return r.Result, nil
 }
 
-/*
-ChangePageRule lets change individual settings for a Page Rule. This is in
-contrast to UpdatePageRule which replaces the entire Page Rule.
-
-API reference:
-  https://api.cloudflare.com/#page-rules-for-a-zone-change-a-page-rule
-  PATCH /zones/:zone_identifier/pagerules/:identifier
-*/
+// ChangePageRule lets you change individual settings for a Page Rule. This is
+// in contrast to UpdatePageRule which replaces the entire Page Rule.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-change-a-page-rule
 func (api *API) ChangePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PATCH", uri, rule)
@@ -188,14 +170,10 @@ func (api *API) ChangePageRule(zoneID, ruleID string, rule PageRule) error {
 	return nil
 }
 
-/*
-UpdatePageRule lets you replace a Page Rule. This is in contrast to
-ChangePageRule which lets you change individual settings.
-
-API reference:
-  https://api.cloudflare.com/#page-rules-for-a-zone-update-a-page-rule
-  PUT /zones/:zone_identifier/pagerules/:identifier
-*/
+// UpdatePageRule lets you replace a Page Rule. This is in contrast to
+// ChangePageRule which lets you change individual settings.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-update-a-page-rule
 func (api *API) UpdatePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PUT", uri, nil)
@@ -210,13 +188,9 @@ func (api *API) UpdatePageRule(zoneID, ruleID string, rule PageRule) error {
 	return nil
 }
 
-/*
-DeletePageRule deletes a Page Rule for a zone.
-
-API reference:
-  https://api.cloudflare.com/#page-rules-for-a-zone-delete-a-page-rule
-  DELETE /zones/:zone_identifier/pagerules/:identifier
-*/
+// DeletePageRule deletes a Page Rule for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-delete-a-page-rule
 func (api *API) DeletePageRule(zoneID, ruleID string) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("DELETE", uri, nil)

--- a/vendor/github.com/cloudflare/cloudflare-go/railgun.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/railgun.go
@@ -46,11 +46,10 @@ type railgunsResponse struct {
 }
 
 // CreateRailgun creates a new Railgun.
-// API reference:
-// 	https://api.cloudflare.com/#railgun-create-railgun
-// 	POST /railguns
+//
+// API reference: https://api.cloudflare.com/#railgun-create-railgun
 func (api *API) CreateRailgun(name string) (Railgun, error) {
-	uri := "/railguns"
+	uri := api.userBaseURL("") + "/railguns"
 	params := struct {
 		Name string `json:"name"`
 	}{
@@ -68,15 +67,14 @@ func (api *API) CreateRailgun(name string) (Railgun, error) {
 }
 
 // ListRailguns lists Railguns connected to an account.
-// API reference:
-//  https://api.cloudflare.com/#railgun-list-railguns
-//  GET /railguns
+//
+// API reference: https://api.cloudflare.com/#railgun-list-railguns
 func (api *API) ListRailguns(options RailgunListOptions) ([]Railgun, error) {
 	v := url.Values{}
 	if options.Direction != "" {
 		v.Set("direction", options.Direction)
 	}
-	uri := "/railguns" + "?" + v.Encode()
+	uri := api.userBaseURL("") + "/railguns" + "?" + v.Encode()
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)
@@ -89,11 +87,10 @@ func (api *API) ListRailguns(options RailgunListOptions) ([]Railgun, error) {
 }
 
 // RailgunDetails returns the details for a Railgun.
-// API reference:
-// 	https://api.cloudflare.com/#railgun-railgun-details
-// 	GET /railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railgun-railgun-details
 func (api *API) RailgunDetails(railgunID string) (Railgun, error) {
-	uri := "/railguns/" + railgunID
+	uri := api.userBaseURL("") + "/railguns/" + railgunID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return Railgun{}, errors.Wrap(err, errMakeRequestError)
@@ -106,11 +103,10 @@ func (api *API) RailgunDetails(railgunID string) (Railgun, error) {
 }
 
 // RailgunZones returns the zones that are currently using a Railgun.
-// API reference:
-// 	https://api.cloudflare.com/#railgun-get-zones-connected-to-a-railgun
-// 	GET /railguns/:identifier/zones
+//
+// API reference: https://api.cloudflare.com/#railgun-get-zones-connected-to-a-railgun
 func (api *API) RailgunZones(railgunID string) ([]Zone, error) {
-	uri := "/railguns/" + railgunID + "/zones"
+	uri := api.userBaseURL("") + "/railguns/" + railgunID + "/zones"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)
@@ -123,11 +119,10 @@ func (api *API) RailgunZones(railgunID string) ([]Zone, error) {
 }
 
 // enableRailgun enables (true) or disables (false) a Railgun for all zones connected to it.
-// API reference:
-//  https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
-//  PATCH /railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
 func (api *API) enableRailgun(railgunID string, enable bool) (Railgun, error) {
-	uri := "/railguns/" + railgunID
+	uri := api.userBaseURL("") + "/railguns/" + railgunID
 	params := struct {
 		Enabled bool `json:"enabled"`
 	}{
@@ -145,27 +140,24 @@ func (api *API) enableRailgun(railgunID string, enable bool) (Railgun, error) {
 }
 
 // EnableRailgun enables a Railgun for all zones connected to it.
-// API reference:
-//  https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
-//  PATCH /railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
 func (api *API) EnableRailgun(railgunID string) (Railgun, error) {
 	return api.enableRailgun(railgunID, true)
 }
 
 // DisableRailgun enables a Railgun for all zones connected to it.
-// API reference:
-//  https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
-//  PATCH /railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
 func (api *API) DisableRailgun(railgunID string) (Railgun, error) {
 	return api.enableRailgun(railgunID, false)
 }
 
 // DeleteRailgun disables and deletes a Railgun.
-// API reference:
-// 	https://api.cloudflare.com/#railgun-delete-railgun
-// 	DELETE /railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railgun-delete-railgun
 func (api *API) DeleteRailgun(railgunID string) error {
-	uri := "/railguns/" + railgunID
+	uri := api.userBaseURL("") + "/railguns/" + railgunID
 	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
 		return errors.Wrap(err, errMakeRequestError)
 	}
@@ -222,9 +214,8 @@ type railgunDiagnosisResponse struct {
 }
 
 // ZoneRailguns returns the available Railguns for a zone.
-// API reference:
-// 	https://api.cloudflare.com/#railguns-for-a-zone-get-available-railguns
-// 	GET /zones/:zone_identifier/railguns
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-get-available-railguns
 func (api *API) ZoneRailguns(zoneID string) ([]ZoneRailgun, error) {
 	uri := "/zones/" + zoneID + "/railguns"
 	res, err := api.makeRequest("GET", uri, nil)
@@ -239,9 +230,8 @@ func (api *API) ZoneRailguns(zoneID string) ([]ZoneRailgun, error) {
 }
 
 // ZoneRailgunDetails returns the configuration for a given Railgun.
-// API reference:
-// 	https://api.cloudflare.com/#railguns-for-a-zone-get-railgun-details
-// 	GET /zones/:zone_identifier/railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-get-railgun-details
 func (api *API) ZoneRailgunDetails(zoneID, railgunID string) (ZoneRailgun, error) {
 	uri := "/zones/" + zoneID + "/railguns/" + railgunID
 	res, err := api.makeRequest("GET", uri, nil)
@@ -256,9 +246,8 @@ func (api *API) ZoneRailgunDetails(zoneID, railgunID string) (ZoneRailgun, error
 }
 
 // TestRailgunConnection tests a Railgun connection for a given zone.
-// API reference:
-//  https://api.cloudflare.com/#railgun-connections-for-a-zone-test-railgun-connection
-//  GET /zones/:zone_identifier/railguns/:identifier/diagnose
+//
+// API reference: https://api.cloudflare.com/#railgun-connections-for-a-zone-test-railgun-connection
 func (api *API) TestRailgunConnection(zoneID, railgunID string) (RailgunDiagnosis, error) {
 	uri := "/zones/" + zoneID + "/railguns/" + railgunID + "/diagnose"
 	res, err := api.makeRequest("GET", uri, nil)
@@ -273,9 +262,8 @@ func (api *API) TestRailgunConnection(zoneID, railgunID string) (RailgunDiagnosi
 }
 
 // connectZoneRailgun connects (true) or disconnects (false) a Railgun for a given zone.
-// API reference:
-//  https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
-//  PATCH /zones/:zone_identifier/railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
 func (api *API) connectZoneRailgun(zoneID, railgunID string, connect bool) (ZoneRailgun, error) {
 	uri := "/zones/" + zoneID + "/railguns/" + railgunID
 	params := struct {
@@ -295,17 +283,15 @@ func (api *API) connectZoneRailgun(zoneID, railgunID string, connect bool) (Zone
 }
 
 // ConnectZoneRailgun connects a Railgun for a given zone.
-// API reference:
-// 	https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
-// 	PATCH /zones/:zone_identifier/railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
 func (api *API) ConnectZoneRailgun(zoneID, railgunID string) (ZoneRailgun, error) {
 	return api.connectZoneRailgun(zoneID, railgunID, true)
 }
 
 // DisconnectZoneRailgun disconnects a Railgun for a given zone.
-// API reference:
-//  https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
-//  PATCH /zones/:zone_identifier/railguns/:identifier
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
 func (api *API) DisconnectZoneRailgun(zoneID, railgunID string) (ZoneRailgun, error) {
 	return api.connectZoneRailgun(zoneID, railgunID, false)
 }

--- a/vendor/github.com/cloudflare/cloudflare-go/ssl.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/ssl.go
@@ -51,9 +51,8 @@ type ZoneCustomSSLPriority struct {
 }
 
 // CreateSSL allows you to add a custom SSL certificate to the given zone.
-// API reference:
-// 	https://api.cloudflare.com/#custom-ssl-for-a-zone-create-ssl-configuration
-// 	POST /zones/:zone_identifier/custom_certificates
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-create-ssl-configuration
 func (api *API) CreateSSL(zoneID string, options ZoneCustomSSLOptions) (ZoneCustomSSL, error) {
 	uri := "/zones/" + zoneID + "/custom_certificates"
 	res, err := api.makeRequest("POST", uri, options)
@@ -68,9 +67,8 @@ func (api *API) CreateSSL(zoneID string, options ZoneCustomSSLOptions) (ZoneCust
 }
 
 // ListSSL lists the custom certificates for the given zone.
-// API reference:
-// 	https://api.cloudflare.com/#custom-ssl-for-a-zone-list-ssl-configurations
-// 	GET /zones/:zone_identifier/custom_certificates
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-list-ssl-configurations
 func (api *API) ListSSL(zoneID string) ([]ZoneCustomSSL, error) {
 	uri := "/zones/" + zoneID + "/custom_certificates"
 	res, err := api.makeRequest("GET", uri, nil)
@@ -85,9 +83,8 @@ func (api *API) ListSSL(zoneID string) ([]ZoneCustomSSL, error) {
 }
 
 // SSLDetails returns the configuration details for a custom SSL certificate.
-// API reference:
-// 	https://api.cloudflare.com/#custom-ssl-for-a-zone-ssl-configuration-details
-// 	GET /zones/:zone_identifier/custom_certificates/:identifier
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-ssl-configuration-details
 func (api *API) SSLDetails(zoneID, certificateID string) (ZoneCustomSSL, error) {
 	uri := "/zones/" + zoneID + "/custom_certificates/" + certificateID
 	res, err := api.makeRequest("GET", uri, nil)
@@ -102,9 +99,8 @@ func (api *API) SSLDetails(zoneID, certificateID string) (ZoneCustomSSL, error) 
 }
 
 // UpdateSSL updates (replaces) a custom SSL certificate.
-// API reference:
-// 	https://api.cloudflare.com/#custom-ssl-for-a-zone-update-ssl-configuration
-// 	PATCH /zones/:zone_identifier/custom_certificates/:identifier
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-update-ssl-configuration
 func (api *API) UpdateSSL(zoneID, certificateID string, options ZoneCustomSSLOptions) (ZoneCustomSSL, error) {
 	uri := "/zones/" + zoneID + "/custom_certificates/" + certificateID
 	res, err := api.makeRequest("PATCH", uri, options)
@@ -120,9 +116,8 @@ func (api *API) UpdateSSL(zoneID, certificateID string, options ZoneCustomSSLOpt
 
 // ReprioritizeSSL allows you to change the priority (which is served for a given
 // request) of custom SSL certificates associated with the given zone.
-// API reference:
-// 	https://api.cloudflare.com/#custom-ssl-for-a-zone-re-prioritize-ssl-certificates
-// 	PUT /zones/:zone_identifier/custom_certificates/prioritize
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-re-prioritize-ssl-certificates
 func (api *API) ReprioritizeSSL(zoneID string, p []ZoneCustomSSLPriority) ([]ZoneCustomSSL, error) {
 	uri := "/zones/" + zoneID + "/custom_certificates/prioritize"
 	params := struct {
@@ -142,9 +137,8 @@ func (api *API) ReprioritizeSSL(zoneID string, p []ZoneCustomSSLPriority) ([]Zon
 }
 
 // DeleteSSL deletes a custom SSL certificate from the given zone.
-// API reference:
-// 	https://api.cloudflare.com/#custom-ssl-for-a-zone-delete-an-ssl-certificate
-// 	DELETE /zones/:zone_identifier/custom_certificates/:identifier
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-delete-an-ssl-certificate
 func (api *API) DeleteSSL(zoneID, certificateID string) error {
 	uri := "/zones/" + zoneID + "/custom_certificates/" + certificateID
 	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {

--- a/vendor/github.com/cloudflare/cloudflare-go/user.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/user.go
@@ -9,20 +9,20 @@ import (
 
 // User describes a user account.
 type User struct {
-	ID            string         `json:"id"`
-	Email         string         `json:"email"`
-	FirstName     string         `json:"first_name"`
-	LastName      string         `json:"last_name"`
-	Username      string         `json:"username"`
-	Telephone     string         `json:"telephone"`
-	Country       string         `json:"country"`
-	Zipcode       string         `json:"zipcode"`
-	CreatedOn     time.Time      `json:"created_on"`
-	ModifiedOn    time.Time      `json:"modified_on"`
-	APIKey        string         `json:"api_key"`
-	TwoFA         bool           `json:"two_factor_authentication_enabled"`
-	Betas         []string       `json:"betas"`
-	Organizations []Organization `json:"organizations"`
+	ID            string         `json:"id,omitempty"`
+	Email         string         `json:"email,omitempty"`
+	FirstName     string         `json:"first_name,omitempty"`
+	LastName      string         `json:"last_name,omitempty"`
+	Username      string         `json:"username,omitempty"`
+	Telephone     string         `json:"telephone,omitempty"`
+	Country       string         `json:"country,omitempty"`
+	Zipcode       string         `json:"zipcode,omitempty"`
+	CreatedOn     *time.Time     `json:"created_on,omitempty"`
+	ModifiedOn    *time.Time     `json:"modified_on,omitempty"`
+	APIKey        string         `json:"api_key,omitempty"`
+	TwoFA         bool           `json:"two_factor_authentication_enabled,omitempty"`
+	Betas         []string       `json:"betas,omitempty"`
+	Organizations []Organization `json:"organizations,omitempty"`
 }
 
 // UserResponse wraps a response containing User accounts.
@@ -31,10 +31,36 @@ type UserResponse struct {
 	Result User `json:"result"`
 }
 
+// userBillingProfileResponse wraps a response containing Billing Profile information.
+type userBillingProfileResponse struct {
+	Response
+	Result UserBillingProfile
+}
+
+// UserBillingProfile contains Billing Profile information.
+type UserBillingProfile struct {
+	ID              string     `json:"id,omitempty"`
+	FirstName       string     `json:"first_name,omitempty"`
+	LastName        string     `json:"last_name,omitempty"`
+	Address         string     `json:"address,omitempty"`
+	Address2        string     `json:"address2,omitempty"`
+	Company         string     `json:"company,omitempty"`
+	City            string     `json:"city,omitempty"`
+	State           string     `json:"state,omitempty"`
+	ZipCode         string     `json:"zipcode,omitempty"`
+	Country         string     `json:"country,omitempty"`
+	Telephone       string     `json:"telephone,omitempty"`
+	CardNumber      string     `json:"card_number,omitempty"`
+	CardExpiryYear  int        `json:"card_expiry_year,omitempty"`
+	CardExpiryMonth int        `json:"card_expiry_month,omitempty"`
+	VAT             string     `json:"vat,omitempty"`
+	CreatedOn       *time.Time `json:"created_on,omitempty"`
+	EditedOn        *time.Time `json:"edited_on,omitempty"`
+}
+
 // UserDetails provides information about the logged-in user.
-// API reference:
-// 	https://api.cloudflare.com/#user-user-details
-//	GET /user
+//
+// API reference: https://api.cloudflare.com/#user-user-details
 func (api *API) UserDetails() (User, error) {
 	var r UserResponse
 	res, err := api.makeRequest("GET", "/user", nil)
@@ -51,10 +77,37 @@ func (api *API) UserDetails() (User, error) {
 }
 
 // UpdateUser updates the properties of the given user.
-// API reference:
-// 	https://api.cloudflare.com/#user-update-user
-//	PATCH /user
-func (api *API) UpdateUser() (User, error) {
-	// api.makeRequest("PATCH", "/user", user)
-	return User{}, nil
+//
+// API reference: https://api.cloudflare.com/#user-update-user
+func (api *API) UpdateUser(user *User) (User, error) {
+	var r UserResponse
+	res, err := api.makeRequest("PATCH", "/user", user)
+	if err != nil {
+		return User{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return User{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}
+
+// UserBillingProfile returns the billing profile of the user.
+//
+// API reference: https://api.cloudflare.com/#user-billing-profile
+func (api *API) UserBillingProfile() (UserBillingProfile, error) {
+	var r userBillingProfileResponse
+	res, err := api.makeRequest("GET", "/user/billing/profile", nil)
+	if err != nil {
+		return UserBillingProfile{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return UserBillingProfile{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
 }

--- a/vendor/github.com/cloudflare/cloudflare-go/user_agent.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/user_agent.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// UserAgentRule represents a User-Agent Block. These rules can be used to
+// challenge, block or whitelist specific User-Agents for a given zone.
+type UserAgentRule struct {
+	ID            string              `json:"id"`
+	Description   string              `json:"description"`
+	Mode          string              `json:"mode"`
+	Configuration UserAgentRuleConfig `json:"configuration"`
+	Paused        bool                `json:"paused"`
+}
+
+// UserAgentRuleConfig represents a Zone Lockdown config, which comprises
+// a Target ("ip" or "ip_range") and a Value (an IP address or IP+mask,
+// respectively.)
+type UserAgentRuleConfig ZoneLockdownConfig
+
+// UserAgentRuleResponse represents a response from the Zone Lockdown endpoint.
+type UserAgentRuleResponse struct {
+	Result UserAgentRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// UserAgentRuleListResponse represents a response from the List Zone Lockdown endpoint.
+type UserAgentRuleListResponse struct {
+	Result []UserAgentRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// CreateUserAgentRule creates a User-Agent Block rule for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-create-a-useragent-rule
+func (api *API) CreateUserAgentRule(zoneID string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
+	switch ld.Mode {
+	case "block", "challenge", "js_challenge", "whitelist":
+		break
+	default:
+		return nil, errors.New(`the User-Agent Block rule mode must be one of "block", "challenge", "js_challenge", "whitelist"`)
+	}
+
+	uri := "/zones/" + zoneID + "/firewall/ua_rules"
+	res, err := api.makeRequest("POST", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateUserAgentRule updates a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-update-useragent-rule
+func (api *API) UpdateUserAgentRule(zoneID string, id string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("PUT", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// DeleteUserAgentRule deletes a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-delete-useragent-rule
+func (api *API) DeleteUserAgentRule(zoneID string, id string) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UserAgentRule retrieves a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-useragent-rule-details
+func (api *API) UserAgentRule(zoneID string, id string) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ListUserAgentRules retrieves a list of User-Agent Block rules for a given zone ID by page number.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-list-useragent-rules
+func (api *API) ListUserAgentRules(zoneID string, page int) (*UserAgentRuleListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/firewall/ua_rules" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/virtualdns.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/virtualdns.go
@@ -31,9 +31,8 @@ type VirtualDNSListResponse struct {
 }
 
 // CreateVirtualDNS creates a new Virtual DNS cluster.
-// API reference:
-//   https://api.cloudflare.com/#virtual-dns-users--create-a-virtual-dns-cluster
-//   POST /user/virtual_dns
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--create-a-virtual-dns-cluster
 func (api *API) CreateVirtualDNS(v *VirtualDNS) (*VirtualDNS, error) {
 	res, err := api.makeRequest("POST", "/user/virtual_dns", v)
 	if err != nil {
@@ -50,9 +49,8 @@ func (api *API) CreateVirtualDNS(v *VirtualDNS) (*VirtualDNS, error) {
 }
 
 // VirtualDNS fetches a single virtual DNS cluster.
-// API reference:
-//   https://api.cloudflare.com/#virtual-dns-users--get-a-virtual-dns-cluster
-//   GET /user/virtual_dns/:identifier
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--get-a-virtual-dns-cluster
 func (api *API) VirtualDNS(virtualDNSID string) (*VirtualDNS, error) {
 	uri := "/user/virtual_dns/" + virtualDNSID
 	res, err := api.makeRequest("GET", uri, nil)
@@ -70,9 +68,8 @@ func (api *API) VirtualDNS(virtualDNSID string) (*VirtualDNS, error) {
 }
 
 // ListVirtualDNS lists the virtual DNS clusters associated with an account.
-// API reference:
-//   https://api.cloudflare.com/#virtual-dns-users--get-virtual-dns-clusters
-//   GET /user/virtual_dns
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--get-virtual-dns-clusters
 func (api *API) ListVirtualDNS() ([]*VirtualDNS, error) {
 	res, err := api.makeRequest("GET", "/user/virtual_dns", nil)
 	if err != nil {
@@ -89,9 +86,8 @@ func (api *API) ListVirtualDNS() ([]*VirtualDNS, error) {
 }
 
 // UpdateVirtualDNS updates a Virtual DNS cluster.
-// API reference:
-//   https://api.cloudflare.com/#virtual-dns-users--modify-a-virtual-dns-cluster
-//   PATCH /user/virtual_dns/:identifier
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--modify-a-virtual-dns-cluster
 func (api *API) UpdateVirtualDNS(virtualDNSID string, vv VirtualDNS) error {
 	uri := "/user/virtual_dns/" + virtualDNSID
 	res, err := api.makeRequest("PUT", uri, vv)
@@ -110,9 +106,8 @@ func (api *API) UpdateVirtualDNS(virtualDNSID string, vv VirtualDNS) error {
 
 // DeleteVirtualDNS deletes a Virtual DNS cluster. Note that this cannot be
 // undone, and will stop all traffic to that cluster.
-// API reference:
-//   https://api.cloudflare.com/#virtual-dns-users--delete-a-virtual-dns-cluster
-//   DELETE /user/virtual_dns/:identifier
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--delete-a-virtual-dns-cluster
 func (api *API) DeleteVirtualDNS(virtualDNSID string) error {
 	uri := "/user/virtual_dns/" + virtualDNSID
 	res, err := api.makeRequest("DELETE", uri, nil)

--- a/vendor/github.com/cloudflare/cloudflare-go/zone.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/zone.go
@@ -18,22 +18,24 @@ type Owner struct {
 
 // Zone describes a Cloudflare zone.
 type Zone struct {
-	ID                string    `json:"id"`
-	Name              string    `json:"name"`
-	DevMode           int       `json:"development_mode"`
-	OriginalNS        []string  `json:"original_name_servers"`
-	OriginalRegistrar string    `json:"original_registrar"`
-	OriginalDNSHost   string    `json:"original_dnshost"`
-	CreatedOn         time.Time `json:"created_on"`
-	ModifiedOn        time.Time `json:"modified_on"`
-	NameServers       []string  `json:"name_servers"`
-	Owner             Owner     `json:"owner"`
-	Permissions       []string  `json:"permissions"`
-	Plan              ZonePlan  `json:"plan"`
-	PlanPending       ZonePlan  `json:"plan_pending,omitempty"`
-	Status            string    `json:"status"`
-	Paused            bool      `json:"paused"`
-	Type              string    `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// DevMode contains the time in seconds until development expires (if
+	// positive) or since it expired (if negative). It will be 0 if never used.
+	DevMode           int          `json:"development_mode"`
+	OriginalNS        []string     `json:"original_name_servers"`
+	OriginalRegistrar string       `json:"original_registrar"`
+	OriginalDNSHost   string       `json:"original_dnshost"`
+	CreatedOn         time.Time    `json:"created_on"`
+	ModifiedOn        time.Time    `json:"modified_on"`
+	NameServers       []string     `json:"name_servers"`
+	Owner             Owner        `json:"owner"`
+	Permissions       []string     `json:"permissions"`
+	Plan              ZoneRatePlan `json:"plan"`
+	PlanPending       ZoneRatePlan `json:"plan_pending,omitempty"`
+	Status            string       `json:"status"`
+	Paused            bool         `json:"paused"`
+	Type              string       `json:"type"`
 	Host              struct {
 		Name    string
 		Website string
@@ -44,7 +46,7 @@ type Zone struct {
 	Meta        ZoneMeta `json:"meta"`
 }
 
-// ZoneMeta metadata about a zone.
+// ZoneMeta describes metadata about a zone.
 type ZoneMeta struct {
 	// custom_certificate_quota is broken - sometimes it's a string, sometimes a number!
 	// CustCertQuota     int    `json:"custom_certificate_quota"`
@@ -53,16 +55,21 @@ type ZoneMeta struct {
 	PhishingDetected  bool `json:"phishing_detected"`
 }
 
-// ZonePlan contains the plan information for a zone.
-type ZonePlan struct {
-	ID           string `json:"id"`
-	Name         string `json:"name,omitempty"`
-	Price        int    `json:"price,omitempty"`
-	Currency     string `json:"currency,omitempty"`
-	Frequency    string `json:"frequency,omitempty"`
-	LegacyID     string `json:"legacy_id,omitempty"`
-	IsSubscribed bool   `json:"is_subscribed,omitempty"`
-	CanSubscribe bool   `json:"can_subscribe,omitempty"`
+// ZoneRatePlan contains the plan information for a zone.
+type ZoneRatePlan struct {
+	ID         string                   `json:"id"`
+	Name       string                   `json:"name,omitempty"`
+	Price      int                      `json:"price,omitempty"`
+	Currency   string                   `json:"currency,omitempty"`
+	Duration   int                      `json:"duration,omitempty"`
+	Frequency  string                   `json:"frequency,omitempty"`
+	Components []zoneRatePlanComponents `json:"components,omitempty"`
+}
+
+type zoneRatePlanComponents struct {
+	Name      string `json:"name"`
+	Default   int    `json:"Default"`
+	UnitPrice int    `json:"unit_price"`
 }
 
 // ZoneID contains only the zone ID.
@@ -88,17 +95,17 @@ type ZoneIDResponse struct {
 	Result ZoneID `json:"result"`
 }
 
-// AvailableZonePlansResponse represents the response from the Available Plans endpoint.
-type AvailableZonePlansResponse struct {
+// AvailableZoneRatePlansResponse represents the response from the Available Rate Plans endpoint.
+type AvailableZoneRatePlansResponse struct {
 	Response
-	Result []ZonePlan `json:"result"`
+	Result []ZoneRatePlan `json:"result"`
 	ResultInfo
 }
 
-// ZonePlanResponse represents the response from the Plan Details endpoint.
-type ZonePlanResponse struct {
+// ZoneRatePlanResponse represents the response from the Plan Details endpoint.
+type ZoneRatePlanResponse struct {
 	Response
-	Result ZonePlan `json:"result"`
+	Result ZoneRatePlan `json:"result"`
 }
 
 // ZoneSetting contains settings for a zone.
@@ -114,6 +121,21 @@ type ZoneSetting struct {
 type ZoneSettingResponse struct {
 	Response
 	Result []ZoneSetting `json:"result"`
+}
+
+// ZoneSSLSetting contains ssl setting for a zone.
+type ZoneSSLSetting struct {
+	ID                string `json:"id"`
+	Editable          bool   `json:"editable"`
+	ModifiedOn        string `json:"modified_on"`
+	Value             string `json:"value"`
+	CertificateStatus string `json:"certificate_status"`
+}
+
+// ZoneSettingResponse represents the response from the Zone SSL Setting endpoint.
+type ZoneSSLSettingResponse struct {
+	Response
+	Result ZoneSSLSetting `json:"result"`
 }
 
 // ZoneAnalyticsData contains totals and timeseries analytics data for a zone.
@@ -191,14 +213,22 @@ type ZoneAnalyticsOptions struct {
 
 // PurgeCacheRequest represents the request format made to the purge endpoint.
 type PurgeCacheRequest struct {
-	Everything bool     `json:"purge_everything,omitempty"`
-	Files      []string `json:"files,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
+	Everything bool `json:"purge_everything,omitempty"`
+	// Purge by filepath (exact match). Limit of 30
+	Files []string `json:"files,omitempty"`
+	// Purge by Tag (Enterprise only):
+	// https://support.cloudflare.com/hc/en-us/articles/206596608-How-to-Purge-Cache-Using-Cache-Tags-Enterprise-only-
+	Tags []string `json:"tags,omitempty"`
+	// Purge by hostname - e.g. "assets.example.com"
+	Hosts []string `json:"hosts,omitempty"`
 }
 
 // PurgeCacheResponse represents the response from the purge endpoint.
 type PurgeCacheResponse struct {
 	Response
+	Result struct {
+		ID string `json:"id"`
+	} `json:"result"`
 }
 
 // newZone describes a new zone.
@@ -211,6 +241,12 @@ type newZone struct {
 }
 
 // CreateZone creates a zone on an account.
+//
+// Setting jumpstart to true will attempt to automatically scan for existing
+// DNS records. Setting this to false will create the zone with no DNS records.
+//
+// If Organization is non-empty, it must have at least the ID field populated.
+// This will add the new zone to the specified multi-user organization.
 //
 // API reference: https://api.cloudflare.com/#zone-create-a-zone
 func (api *API) CreateZone(name string, jumpstart bool, org Organization) (Zone, error) {
@@ -315,17 +351,15 @@ func (api *API) ZoneDetails(zoneID string) (Zone, error) {
 
 // ZoneOptions is a subset of Zone, for editable options.
 type ZoneOptions struct {
-	// FIXME(jamesog): Using omitempty here means we can't disable Paused.
-	// Currently unsure how to work around this.
-	Paused   bool      `json:"paused,omitempty"`
-	VanityNS []string  `json:"vanity_name_servers,omitempty"`
-	Plan     *ZonePlan `json:"plan,omitempty"`
+	Paused   *bool         `json:"paused,omitempty"`
+	VanityNS []string      `json:"vanity_name_servers,omitempty"`
+	Plan     *ZoneRatePlan `json:"plan,omitempty"`
 }
 
 // ZoneSetPaused pauses Cloudflare service for the entire zone, sending all
 // traffic direct to the origin.
 func (api *API) ZoneSetPaused(zoneID string, paused bool) (Zone, error) {
-	zoneopts := ZoneOptions{Paused: paused}
+	zoneopts := ZoneOptions{Paused: &paused}
 	zone, err := api.EditZone(zoneID, zoneopts)
 	if err != nil {
 		return Zone{}, err
@@ -346,8 +380,8 @@ func (api *API) ZoneSetVanityNS(zoneID string, ns []string) (Zone, error) {
 	return zone, nil
 }
 
-// ZoneSetPlan changes the zone plan.
-func (api *API) ZoneSetPlan(zoneID string, plan ZonePlan) (Zone, error) {
+// ZoneSetRatePlan changes the zone plan.
+func (api *API) ZoneSetRatePlan(zoneID string, plan ZoneRatePlan) (Zone, error) {
 	zoneopts := ZoneOptions{Plan: &plan}
 	zone, err := api.EditZone(zoneID, zoneopts)
 	if err != nil {
@@ -358,6 +392,7 @@ func (api *API) ZoneSetPlan(zoneID string, plan ZonePlan) (Zone, error) {
 }
 
 // EditZone edits the given zone.
+//
 // This is usually called by ZoneSetPaused, ZoneSetVanityNS or ZoneSetPlan.
 //
 // API reference: https://api.cloudflare.com/#zone-edit-zone-properties
@@ -376,13 +411,14 @@ func (api *API) EditZone(zoneID string, zoneOpts ZoneOptions) (Zone, error) {
 }
 
 // PurgeEverything purges the cache for the given zone.
+//
 // Note: this will substantially increase load on the origin server for that
 // zone if there is a high cached vs. uncached request ratio.
 //
 // API reference: https://api.cloudflare.com/#zone-purge-all-files
 func (api *API) PurgeEverything(zoneID string) (PurgeCacheResponse, error) {
 	uri := "/zones/" + zoneID + "/purge_cache"
-	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil})
+	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil, nil})
 	if err != nil {
 		return PurgeCacheResponse{}, errors.Wrap(err, errMakeRequestError)
 	}
@@ -427,36 +463,19 @@ func (api *API) DeleteZone(zoneID string) (ZoneID, error) {
 	return r.Result, nil
 }
 
-// AvailableZonePlans returns information about all plans available to the specified zone.
+// AvailableZoneRatePlans returns information about all plans available to the specified zone.
 //
 // API reference: https://api.cloudflare.com/#zone-plan-available-plans
-func (api *API) AvailableZonePlans(zoneID string) ([]ZonePlan, error) {
-	uri := "/zones/" + zoneID + "/available_plans"
+func (api *API) AvailableZoneRatePlans(zoneID string) ([]ZoneRatePlan, error) {
+	uri := "/zones/" + zoneID + "/available_rate_plans"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []ZonePlan{}, errors.Wrap(err, errMakeRequestError)
+		return []ZoneRatePlan{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r AvailableZonePlansResponse
+	var r AvailableZoneRatePlansResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []ZonePlan{}, errors.Wrap(err, errUnmarshalError)
-	}
-	return r.Result, nil
-}
-
-// ZonePlanDetails returns information about a zone plan.
-//
-// API reference: https://api.cloudflare.com/#zone-plan-plan-details
-func (api *API) ZonePlanDetails(zoneID, planID string) (ZonePlan, error) {
-	uri := "/zones/" + zoneID + "/available_plans/" + planID
-	res, err := api.makeRequest("GET", uri, nil)
-	if err != nil {
-		return ZonePlan{}, errors.Wrap(err, errMakeRequestError)
-	}
-	var r ZonePlanResponse
-	err = json.Unmarshal(res, &r)
-	if err != nil {
-		return ZonePlan{}, errors.Wrap(err, errUnmarshalError)
+		return []ZoneRatePlan{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -478,9 +497,7 @@ func (o ZoneAnalyticsOptions) encode() string {
 
 // ZoneAnalyticsDashboard returns zone analytics information.
 //
-// API reference:
-//  https://api.cloudflare.com/#zone-analytics-dashboard
-//  GET /zones/:zone_identifier/analytics/dashboard
+// API reference: https://api.cloudflare.com/#zone-analytics-dashboard
 func (api *API) ZoneAnalyticsDashboard(zoneID string, options ZoneAnalyticsOptions) (ZoneAnalyticsData, error) {
 	uri := "/zones/" + zoneID + "/analytics/dashboard" + "?" + options.encode()
 	res, err := api.makeRequest("GET", uri, nil)
@@ -497,9 +514,7 @@ func (api *API) ZoneAnalyticsDashboard(zoneID string, options ZoneAnalyticsOptio
 
 // ZoneAnalyticsByColocation returns zone analytics information by datacenter.
 //
-// API reference:
-//  https://api.cloudflare.com/#zone-analytics-analytics-by-co-locations
-//  GET /zones/:zone_identifier/analytics/colos
+// API reference: https://api.cloudflare.com/#zone-analytics-analytics-by-co-locations
 func (api *API) ZoneAnalyticsByColocation(zoneID string, options ZoneAnalyticsOptions) ([]ZoneAnalyticsColocation, error) {
 	uri := "/zones/" + zoneID + "/analytics/colos" + "?" + options.encode()
 	res, err := api.makeRequest("GET", uri, nil)
@@ -514,8 +529,59 @@ func (api *API) ZoneAnalyticsByColocation(zoneID string, options ZoneAnalyticsOp
 	return r.Result, nil
 }
 
-// Zone Settings
-// https://api.cloudflare.com/#zone-settings-for-a-zone-get-all-zone-settings
-// e.g.
-// https://api.cloudflare.com/#zone-settings-for-a-zone-get-always-online-setting
-// https://api.cloudflare.com/#zone-settings-for-a-zone-change-always-online-setting
+// ZoneSettings returns all of the settings for a given zone.
+//
+// API reference: https://api.cloudflare.com/#zone-settings-get-all-zone-settings
+func (api *API) ZoneSettings(zoneID string) (*ZoneSettingResponse, error) {
+	uri := "/zones/" + zoneID + "/settings"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneSettingResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateZoneSettings updates the settings for a given zone.
+//
+// API reference: https://api.cloudflare.com/#zone-settings-edit-zone-settings-info
+func (api *API) UpdateZoneSettings(zoneID string, settings []ZoneSetting) (*ZoneSettingResponse, error) {
+	uri := "/zones/" + zoneID + "/settings"
+	res, err := api.makeRequest("PATCH", uri, struct {
+		Items []ZoneSetting `json:"items"`
+	}{settings})
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneSettingResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ZoneSSLSettings returns information about SSL setting to the specified zone.
+//
+// API reference: https://api.cloudflare.com/#zone-settings-get-ssl-setting
+func (api *API) ZoneSSLSettings(zoneID string) (ZoneSSLSetting, error) {
+	uri := "/zones/" + zoneID + "/settings/ssl"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ZoneSSLSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZoneSSLSettingResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return ZoneSSLSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,10 +227,10 @@
 			"revisionTime": "2017-07-27T06:48:18Z"
 		},
 		{
-			"checksumSHA1": "QhYMdplKQJAMptRaHZBB8CF6HdM=",
+			"checksumSHA1": "9yLyTXSuNlBqL2hj4WSkQcZa/4I=",
 			"path": "github.com/cloudflare/cloudflare-go",
-			"revision": "6cfcb7ec3886f434daf8515d14d4ab208cae845c",
-			"revisionTime": "2016-12-21T19:00:05Z"
+			"revision": "4155500e79b003e97c08ee87211bb70c30b3d664",
+			"revisionTime": "2017-12-07T19:44:18Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",


### PR DESCRIPTION
Created this to potentially address the issue here: https://github.com/terraform-providers/terraform-provider-cloudflare/pull/19#issuecomment-358680205

Docs also include record ID format - this does correctly import records with the cloudflare ID from the APIs.

Could probably stand to be optimized some, but this was was an initial attempt at getting cloudflare dns records to import.

Also updates the cloudflare-go libraries to the latest - the current version didn't page records correctly